### PR TITLE
fix(release): disable replace for Darwin universal binaries to preserve existing files

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,7 +47,7 @@ release:
 
 # Creates Darwin universal binaries.
 universal_binaries:
-  - replace: true
+  - replace: false
 
 # Enables source archives.
 source:


### PR DESCRIPTION
- Disabled file replacement for Darwin universal binaries during release
- Ensured existing files are preserved on macOS systems