### PR TITLE
ci: add bun install step to release workflow to ensure dependencies are installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2.0.1
+      - run: bun install
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
- Added a `bun install` step to the release workflow  
- Ensured dependencies are installed during the release process