### PR TITLE
headers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ using log = logger;
 
 export const fetchConfiguration = async (
 	configurationUrl: string | undefined = CONFIGURATION_URL,
+	headers?: Record<string, string>,
 ): Promise<Configuration> => {
 	const timeoutMs = 10000;
 
@@ -27,7 +28,10 @@ export const fetchConfiguration = async (
 	try {
 		response = await fetch(configurationUrl, {
 			method: "GET",
-			headers: { Accept: "application/json" },
+			headers: {
+				...headers,
+				Accept: "application/json",
+			},
 			signal: AbortSignal.timeout(timeoutMs),
 		});
 	} catch (error) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,11 +12,14 @@ using log = logger;
 
 export const server = createServer();
 
-export const proxy = async (configurationUrl?: string) => {
+export const proxy = async (
+	configurationUrl?: string,
+	options?: { headers?: Record<string, string> },
+) => {
 	log.info("MCP Proxy Server starting");
 
 	try {
-		const config = await fetchConfiguration(configurationUrl);
+		const config = await fetchConfiguration(configurationUrl, options?.headers);
 		const transport = new StdioServerTransport();
 
 		setRequestHandlers(server);

--- a/test/unit/proxy.test.ts
+++ b/test/unit/proxy.test.ts
@@ -106,7 +106,25 @@ describe("proxy", () => {
 		await proxy(customConfigUrl);
 
 		// Assert
-		expect(mockFetchConfiguration).toHaveBeenCalledWith(customConfigUrl);
+		expect(mockFetchConfiguration).toHaveBeenCalledWith(
+			customConfigUrl,
+			undefined,
+		);
+	});
+
+	test("accepts headers parameter and passes it to fetchConfiguration", async () => {
+		// Arrange
+		const customConfigUrl = "https://example.com/config.json";
+		const customHeaders = { "X-Custom-Header": "TestValue" };
+
+		// Act
+		await proxy(customConfigUrl, { headers: customHeaders });
+
+		// Assert
+		expect(mockFetchConfiguration).toHaveBeenCalledWith(
+			customConfigUrl,
+			customHeaders,
+		);
 	});
 
 	describe("error handling", () => {


### PR DESCRIPTION
- Added an optional `headers` parameter to the `fetchConfiguration` function to allow passing additional headers when fetching the configuration
- Added an optional `headers` parameter to the `proxy` function to allow passing additional headers when fetching the configuration