### PR TITLE
feat: Bump version and update module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@pyleeai/mcp-proxy-server",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"type": "module",
-	"module": "src/index.ts",
+	"module": "build/index.js",
 	"types": "build/index.d.ts",
 	"bin": {
 		"mcp-proxy-server": "build/main.js"


### PR DESCRIPTION
The changes in this commit include:

- Bump the package version from 0.9.1 to 0.9.2
- Update the `module` field in `package.json` to point to the compiled `build/index.js` file instead of the source `src/index.ts` file

These changes are necessary to ensure the package is correctly published and consumed by downstream projects.