### PR TITLE
disconnect-and-reconnect-clients-on-configuration-change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pyleeai/mcp-proxy-server",
-	"version": "0.9.8-rc.1",
+	"version": "0.9.9-rc.2",
 	"type": "module",
 	"module": "build/index.js",
 	"types": "build/index.d.ts",

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,10 +1,6 @@
 import { createClient } from "./client";
 import { connect } from "./connect";
-import {
-	clearAllClientStates,
-	getAllClientStates,
-	setClientState,
-} from "./data";
+import { setClientState } from "./data";
 import { logger } from "./logger";
 import type { Configuration } from "./types";
 
@@ -13,15 +9,6 @@ using log = logger;
 export const connectClients = async (
 	configuration: Configuration,
 ): Promise<void> => {
-	const clients = getAllClientStates();
-	if (clients.length > 0) {
-		log.info("Disconnecting existing clients");
-		await Promise.allSettled(
-			clients.map(async (client) => client.transport?.close()),
-		);
-		clearAllClientStates();
-	}
-
 	const servers = Object.entries(configuration.mcp.servers);
 
 	if (servers.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export { proxy as MCPProxyServer } from "./proxy";
+export type { Configuration } from "./types";
+export { connectClients } from "./clients";
+export { setRequestHandlers } from "./handlers";

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,13 @@ export const createServer = () => {
 	const server = new Server(
 		{ name, version },
 		{
-			capabilities: { prompts: {}, resources: { subscribe: true }, tools: {} },
+			capabilities: {
+				prompts: {},
+				resources: { subscribe: true },
+				tools: {
+					listChanged: true,
+				},
+			},
 		},
 	);
 

--- a/test/unit/clients.test.ts
+++ b/test/unit/clients.test.ts
@@ -73,11 +73,11 @@ describe("connectClients", () => {
 		await connectClients(configuration);
 
 		// Assert
-		expect(mockGetAllClientStates).toHaveBeenCalledTimes(1);
 		expect(mockLoggerInfo).toHaveBeenCalledWith("No servers to connect");
 		expect(mockCreateClient).not.toHaveBeenCalled();
 		expect(mockConnect).not.toHaveBeenCalled();
 		expect(mockSetClientState).not.toHaveBeenCalled();
+		expect(mockGetAllClientStates).not.toHaveBeenCalled();
 		expect(mockClearAllClientStates).not.toHaveBeenCalled();
 	});
 
@@ -102,12 +102,12 @@ describe("connectClients", () => {
 		await connectClients(configuration);
 
 		// Assert
-		expect(mockGetAllClientStates).toHaveBeenCalledTimes(1);
 		expect(mockLoggerInfo).toHaveBeenCalledWith("Connecting to 3 servers");
 		expect(mockCreateClient).toHaveBeenCalledTimes(3);
 		expect(mockConnect).toHaveBeenCalledTimes(3);
 		expect(mockSetClientState).toHaveBeenCalledTimes(3);
 		expect(mockLoggerInfo).toHaveBeenCalledWith("Connected to 3/3 servers");
+		expect(mockGetAllClientStates).not.toHaveBeenCalled();
 		expect(mockClearAllClientStates).not.toHaveBeenCalled();
 	});
 
@@ -126,7 +126,6 @@ describe("connectClients", () => {
 		await connectClients(configuration);
 
 		// Assert
-		expect(mockGetAllClientStates).toHaveBeenCalledTimes(1);
 		expect(mockLoggerInfo).toHaveBeenCalledWith("Connecting to 2 servers");
 		expect(mockCreateClient).toHaveBeenCalledTimes(2);
 		expect(mockConnect).toHaveBeenCalledTimes(2);
@@ -149,100 +148,8 @@ describe("connectClients", () => {
 			client: mockClient,
 			transport: mockTransport,
 		});
+		expect(mockGetAllClientStates).not.toHaveBeenCalled();
 		expect(mockClearAllClientStates).not.toHaveBeenCalled();
-	});
-
-	test("should disconnect existing clients before connecting new ones", async () => {
-		// Arrange
-		const mockTransport1 = { close: () => Promise.resolve() };
-		const mockClose1 = spyOn(mockTransport1, "close").mockImplementation(() =>
-			Promise.resolve(),
-		);
-		const mockTransport2 = { close: () => Promise.resolve() };
-		const mockClose2 = spyOn(mockTransport2, "close").mockImplementation(() =>
-			Promise.resolve(),
-		);
-
-		const existingTransport1 = mockTransport1 as unknown as Transport;
-		const existingTransport2 = mockTransport2 as unknown as Transport;
-
-		const existingClients: ClientState[] = [
-			{
-				name: "existing1",
-				client: {} as Client,
-				transport: existingTransport1,
-			},
-			{
-				name: "existing2",
-				client: {} as Client,
-				transport: existingTransport2,
-			},
-		];
-
-		mockGetAllClientStates.mockImplementation(() => existingClients);
-
-		const configuration: Configuration = {
-			mcp: {
-				servers: {
-					newServer: { url: "http://new-server.example.com" },
-				},
-			},
-		};
-
-		// Act
-		await connectClients(configuration);
-
-		// Assert
-		expect(mockGetAllClientStates).toHaveBeenCalledTimes(1);
-		expect(mockLoggerInfo).toHaveBeenCalledWith(
-			"Disconnecting existing clients",
-		);
-		expect(mockClose1).toHaveBeenCalledTimes(1);
-		expect(mockClose2).toHaveBeenCalledTimes(1);
-		expect(mockClearAllClientStates).toHaveBeenCalledTimes(1);
-		expect(mockLoggerInfo).toHaveBeenCalledWith("Connecting to 1 servers");
-	});
-
-	test("should handle clients without transport during disconnection", async () => {
-		// Arrange
-		const mockTransport = { close: () => Promise.resolve() };
-		const mockClose = spyOn(mockTransport, "close").mockImplementation(() =>
-			Promise.resolve(),
-		);
-
-		const existingTransport = mockTransport as unknown as Transport;
-
-		const existingClients: ClientState[] = [
-			{
-				name: "existing1",
-				client: {} as Client,
-				transport: existingTransport,
-			},
-			{
-				name: "existing2",
-				client: {} as Client,
-				transport: undefined,
-			},
-		];
-
-		mockGetAllClientStates.mockImplementation(() => existingClients);
-
-		const configuration: Configuration = {
-			mcp: {
-				servers: {},
-			},
-		};
-
-		// Act
-		await connectClients(configuration);
-
-		// Assert
-		expect(mockGetAllClientStates).toHaveBeenCalledTimes(1);
-		expect(mockLoggerInfo).toHaveBeenCalledWith(
-			"Disconnecting existing clients",
-		);
-		expect(mockClose).toHaveBeenCalledTimes(1);
-		expect(mockClearAllClientStates).toHaveBeenCalledTimes(1);
 	});
 
 	test("should connect to multiple servers in parallel", async () => {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -715,6 +715,7 @@ describe("startConfigurationPolling", () => {
 	let mockClearAllClientStates: ReturnType<typeof spyOn>;
 	let loggerInfoSpy: ReturnType<typeof spyOn>;
 	let loggerErrorSpy: ReturnType<typeof spyOn>;
+	let mockServer: MockServer;
 
 	const defaultConfig = { mcp: { servers: {} } };
 
@@ -730,6 +731,11 @@ describe("startConfigurationPolling", () => {
 		mockClearAllClientStates = spyOn(dataModule, "clearAllClientStates");
 		loggerInfoSpy = spyOn(logger, "info");
 		loggerErrorSpy = spyOn(logger, "error");
+		mockServer = {
+			sendResourceListChanged: mock(),
+			sendToolListChanged: mock(),
+			sendPromptListChanged: mock(),
+		};
 	});
 
 	afterEach(() => {
@@ -870,10 +876,14 @@ describe("startConfigurationPolling", () => {
 			throw authError;
 		}
 
+		// Act
+		const pollingPromise = startConfigurationPolling(
+			mockConfigGen(),
+			abortController,
+		);
+
 		// Act & Assert
-		await expect(
-			startConfigurationPolling(mockConfigGen(), abortController),
-		).rejects.toThrow(AuthenticationError);
+		await expect(pollingPromise).rejects.toThrow(AuthenticationError);
 		expect(loggerErrorSpy).not.toHaveBeenCalled();
 	});
 
@@ -923,7 +933,6 @@ describe("startConfigurationPolling", () => {
 		const pollingPromise = startConfigurationPolling(
 			mockConfigGen(),
 			abortController,
-			mockServer as unknown as Server,
 		);
 
 		// Give time for polling to process
@@ -981,7 +990,6 @@ describe("startConfigurationPolling", () => {
 		const pollingPromise = startConfigurationPolling(
 			mockConfigGen(),
 			abortController,
-			mockServer as unknown as Server,
 		);
 
 		// Give time for polling to process

--- a/test/unit/server.test.ts
+++ b/test/unit/server.test.ts
@@ -51,7 +51,9 @@ describe("createServer", () => {
 		expect(options.capabilities).toEqual({
 			prompts: {},
 			resources: { subscribe: true },
-			tools: {},
+			tools: {
+				listChanged: true,
+			},
 		});
 	});
 


### PR DESCRIPTION
Here is the pull request description:

- Disconnect and reconnect clients when the configuration changes
- Clear the client state before establishing new connections
- Simplify the `connectClients` function by removing unnecessary disconnection logic
- Handle dynamic configuration updates in the MCP Proxy Server
- Add support for sending list change notifications to clients when the configuration changes
- Expose the `Configuration` type and `connectClients` and `setRequestHandlers` functions in the public API
- Bump the package version to 0.9.9-rc.2